### PR TITLE
Fix: Resolve Multiple Primary Keys Error in `product_review` Migration

### DIFF
--- a/packages/plugin/src/migrations/1683131541071-ProductReview.ts
+++ b/packages/plugin/src/migrations/1683131541071-ProductReview.ts
@@ -4,7 +4,7 @@ export class productReview1683131541071 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `CREATE TABLE IF NOT EXISTS "product_review" (
-        "id" character varying NOT NULL, 
+        "id" character varying NOT NULL PRIMARY KEY, 
         "product_id" character varying NOT NULL, 
         "product_variant_id" character varying,
         "customer_id" character varying NOT NULL,
@@ -15,9 +15,6 @@ export class productReview1683131541071 implements MigrationInterface {
         "deleted_at" TIMESTAMP WITH TIME ZONE )`
     );
     await queryRunner.query(`
-      ALTER TABLE "product_review"
-      ADD CONSTRAINT "PK_product_review" PRIMARY KEY ("id");
-
       ALTER TABLE "product_review"
       ADD CONSTRAINT "FK_product_review_product_id" FOREIGN KEY ("product_id")
       REFERENCES "product" ("id")


### PR DESCRIPTION
### Summary
This pull request addresses an issue in the `product_review` migration script where an error occurred due to multiple primary keys being set on the `product_review` table.

### Changes Made
- Removed the redundant primary key constraint on the `id` column from the `ALTER TABLE` statement.
- Ensured the primary key is correctly set during the table creation process.
- Simplified the migration script by consolidating the primary key definition into the table creation.

### Error Encountered
During the migration, the following error was encountered:

```sql
error: multiple primary keys for table "product_review" are not allowed
```
This error was triggered because the migration script attempted to add a primary key constraint on the `id` column after it was already defined during table creation. The solution involved removing the redundant `ADD CONSTRAINT "PK_product_review"` statement.

### Testing
- The migration was tested by running it against a fresh database instance to ensure the table is created without errors and the foreign key constraint functions as expected.

### Impact
This change will prevent migration errors related to multiple primary keys, ensuring smoother database migrations for the `product_review` table.

Please review the changes and let me know if there are any concerns or additional improvements needed.
